### PR TITLE
Fix PyPi release issue

### DIFF
--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -2,6 +2,6 @@
 CSV Processor.
 """
 
-__version__ = '2.1.2'
+__version__ = '2.1.4'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
The [release-workflow](https://github.com/openedx/super-csv/runs/4080562035?check_suite_focus=true) failed for version 2.1.3 as the author didn't update the version number in the repository and hence the workflow tried to release the package with a version that already existed on PyPi. This PR aims at releasing the new package to PyPi and fixing the issue