### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
-django-waffle==2.5.0
+django-waffle==2.6.0
     # via edx-django-utils
 djangorestframework==3.13.1
     # via -r requirements/base.in
@@ -50,7 +50,7 @@ jsonfield==3.1.0
     # via edx-celeryutils
 kombu==4.6.11
     # via celery
-newrelic==7.14.0.177
+newrelic==7.16.0.178
     # via edx-django-utils
 pbr==5.9.0
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -104,7 +104,7 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
-django-waffle==2.5.0
+django-waffle==2.6.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -172,7 +172,7 @@ mccabe==0.7.0
     #   pylint
 mock==4.0.3
     # via -r requirements/quality.txt
-newrelic==7.14.0.177
+newrelic==7.16.0.178
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -5,5 +5,5 @@
 
 doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
-readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
+twine                     # Validates README.rst for usage on PyPI

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -46,6 +46,8 @@ click==8.1.3
     #   edx-django-utils
 code-annotations==1.3.0
     # via -r requirements/test.txt
+commonmark==0.9.1
+    # via rich
 coverage[toml]==6.4.2
     # via
     #   -r requirements/test.txt
@@ -70,7 +72,7 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-django-waffle==2.5.0
+django-waffle==2.6.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -78,7 +80,7 @@ djangorestframework==3.13.1
     # via -r requirements/test.txt
 doc8==0.11.2
     # via -r requirements/doc.in
-docutils==0.18.1
+docutils==0.19
     # via
     #   doc8
     #   readme-renderer
@@ -105,7 +107,10 @@ idna==3.3
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==4.12.0
-    # via sphinx
+    # via
+    #   keyring
+    #   sphinx
+    #   twine
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -119,6 +124,8 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
+keyring==23.7.0
+    # via twine
 kombu==4.6.11
     # via
     #   -r requirements/test.txt
@@ -129,7 +136,7 @@ markupsafe==2.1.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.14.0.177
+newrelic==7.16.0.178
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -142,6 +149,8 @@ pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
+pkginfo==1.8.3
+    # via twine
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
@@ -162,6 +171,7 @@ pygments==2.12.0
     # via
     #   doc8
     #   readme-renderer
+    #   rich
     #   sphinx
 pynacl==1.5.0
     # via
@@ -200,11 +210,20 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
 readme-renderer==35.0
-    # via -r requirements/doc.in
+    # via twine
 requests==2.28.1
-    # via sphinx
+    # via
+    #   requests-toolbelt
+    #   sphinx
+    #   twine
+requests-toolbelt==0.9.1
+    # via twine
 restructuredtext-lint==1.4.0
     # via doc8
+rfc3986==2.0.0
+    # via twine
+rich==12.5.1
+    # via twine
 simplejson==3.17.6
     # via -r requirements/test.txt
 six==1.16.0
@@ -215,7 +234,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.2
+sphinx==5.1.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -252,8 +271,14 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   coverage
     #   pytest
+twine==4.0.1
+    # via -r requirements/doc.in
+typing-extensions==4.3.0
+    # via rich
 urllib3==1.26.10
-    # via requests
+    # via
+    #   requests
+    #   twine
 vine==1.3.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
+pip==22.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -72,7 +72,7 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-django-waffle==2.5.0
+django-waffle==2.6.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -124,7 +124,7 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.14.0.177
+newrelic==7.16.0.178
     # via
     #   -r requirements/test.txt
     #   edx-django-utils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-django-waffle==2.5.0
+django-waffle==2.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -84,7 +84,7 @@ markupsafe==2.1.1
     # via jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.14.0.177
+newrelic==7.16.0.178
     # via
     #   -r requirements/base.txt
     #   edx-django-utils

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     version=VERSION,
     description="""CSV Processor""",
     long_description=README + '\n\n' + CHANGELOG,
+    long_description_content_type='text/x-rst',
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/edx/super-csv',

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ commands =
     rm -f docs/modules.rst
     make -C docs clean
     make -C docs html
-    python setup.py check --restructuredtext
+    python setup.py bdist_wheel
+    twine check dist/*
 
 [testenv:quality]
 whitelist_externals = 


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3458