### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ----------
+
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
+  more details.
+
 [3.0.1] - 2022-02-17
 
 * fix: encode the csv data before save

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ import io
 import os
 import re
 import sys
+from datetime import datetime
 from subprocess import check_call
 
-import edx_theme
 from django import setup as django_setup
 from django.conf import settings
 
@@ -62,7 +62,6 @@ django_setup()
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -93,8 +92,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'super-csv'
-copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
-author = edx_theme.AUTHOR
+copyright = f'{datetime.now().year}, Axim Collaborative, Inc' # pylint: disable=redefined-builtin
+author = 'Axim Collaborative, Inc'
 project_title = 'CSV Processor'
 documentation_title = f"{project_title}"
 
@@ -165,16 +164,46 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/super-csv",
+ "repository_branch": "master",
+ "path_to_docs": "docs/",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
@@ -188,13 +217,13 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 #
-# html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #
-# html_favicon = None
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,6 +4,6 @@
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme         # Common theme for all Open edX projects
 Sphinx                    # Documentation builder
 twine                     # Validates README.rst for usage on PyPI

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 amqp==2.6.1
@@ -15,7 +17,11 @@ asgiref==3.6.0
     #   -r requirements/test.txt
     #   django
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
@@ -80,6 +86,7 @@ doc8==1.1.1
 docutils==0.19
     # via
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
@@ -87,8 +94,6 @@ edx-celeryutils==1.2.2
     # via -r requirements/test.txt
 edx-django-utils==5.4.0
     # via -r requirements/test.txt
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -154,6 +159,7 @@ newrelic==8.8.0
 packaging==23.1
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
@@ -174,9 +180,13 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
     # via
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   rich
     #   sphinx
@@ -235,15 +245,19 @@ six==1.16.0
     # via
     #   -r requirements/test.txt
     #   bleach
-    #   edx-sphinx-theme
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -283,6 +297,7 @@ twine==4.0.2
 typing-extensions==4.5.0
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   rich
     #   sqlalchemy
 urllib3==1.26.15


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/edx-sphinx-theme/issues/184