### PR TITLE
docs: Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -15,7 +15,6 @@ metadata:
       icon: "Article"
   annotations:
     openedx.org/arch-interest-groups: "angonz"
-    openedx.org/release: "master"
 spec:
   owner: user:angonz
   type: 'service'


### PR DESCRIPTION
This repo does not need to be directly tagged at release, it is part of edx-platform which gets tagged.  This repo is released via semver.